### PR TITLE
correction for gem name as specified in gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a Spina CMS plugin example, this project is meant to be cut into a gem a
 To start using this project locally, first clone it and add the following lines to your Gemfile:
 
 ```
-gem 'spina-review', path: '/path/to/the/project'
+gem 'spina-reviews', path: '/path/to/the/project'
 ```
 
 Make sure you run the migration installer to get started.


### PR DESCRIPTION
I believe you left of the 's' on reviews here. It wouldn't bundle and when I looked at the gemspec, the gem name was "spina-reviews" as opposed to "spina-review" as you have listed in this snippet.
